### PR TITLE
Make scientific notation number of events to generate possible

### DIFF
--- a/src/RapidSim.C
+++ b/src/RapidSim.C
@@ -94,7 +94,7 @@ int main(int argc, char * argv[])
 	}
 
 	const TString mode = argv[1];
-	const int number = (int)atof(argv[2]);
+	const int number = static_cast<int>(atof(argv[2]));
 	bool saveTree = false;
 	int nToReDecay = 0;
 

--- a/src/RapidSim.C
+++ b/src/RapidSim.C
@@ -94,7 +94,7 @@ int main(int argc, char * argv[])
 	}
 
 	const TString mode = argv[1];
-	const int number = atoi(argv[2]);
+	const int number = (int)atof(argv[2]);
 	bool saveTree = false;
 	int nToReDecay = 0;
 


### PR DESCRIPTION
Simple change from `atoi(argv[2])` to `(int)atof(argv[2])` to allow correct command line parsing of terms like

```
/path/to/RapidSim.exe /path/to/EventType 1e6 1
```