### PR TITLE
add possibility of storing B decay time from external generator + various other edits

### DIFF
--- a/src/RapidConfig.cc
+++ b/src/RapidConfig.cc
@@ -439,6 +439,9 @@ bool RapidConfig::configParticle(unsigned int part, TString command, TString val
 		parts_[part]->setEvtGenDecayModel(value);
 		std::cout << "INFO in RapidConfig::configParticle : set EvtGen decay model for particle " << parts_[part]->name() << std::endl
 			  << "                                    : " << value << std::endl;
+	} else if(command=="Define"){
+		std::cout<<"Define: "<<value<<std::endl;
+		parts_[part]->setEvtGenDefinitions(value);
 	}
 
 	return true;

--- a/src/RapidConfig.h
+++ b/src/RapidConfig.h
@@ -99,6 +99,8 @@ class RapidConfig {
 		//Vtx smearing lookup for each smearing category, placeholder for now
 		//std::map<TString, RapidVtxSmear*> vtxSmearCategories_;
 
+		// std::vector<std::map<TString, double>> definitions_;
+		std::vector<TString> definitions_;
 		//accept reject hist to sculpt kinematics
 		TH1* accRejHisto_;
 		RapidParam* accRejParameterX_;

--- a/src/RapidExternalEvtGen.cc
+++ b/src/RapidExternalEvtGen.cc
@@ -6,10 +6,14 @@
 
 #include "TRandom.h"
 #include "TSystem.h"
+#include "TObjString.h"
 
 #ifdef RAPID_EVTGEN
 #include "EvtGen/EvtGen.hh"
+#include "EvtGenBase/EvtConst.hh"
 #include "EvtGenBase/EvtRandomEngine.hh"
+#include "EvtGenBase/EvtCPUtil.hh"
+#include "EvtGenBase/EvtHepMCEvent.hh"
 #include "EvtGenBase/EvtAbsRadCorr.hh"
 #include "EvtGenBase/EvtDecayBase.hh"
 #include "EvtGenBase/EvtParticle.hh"
@@ -21,77 +25,155 @@
 #include "EvtGenExternal/EvtExternalGenList.hh"
 #endif
 
+int B0Id( 511 ), B0barId( -511 );
+int BsId( 531 ), BsbarId( -531 );
+
+
 bool RapidExternalEvtGen::decay(std::vector<RapidParticle*>& parts) {
 #ifdef RAPID_EVTGEN
-	EvtParticle* theParent(0);
 
 	if(parts.size() < 1) {
 		std::cout << "WARNING in RapidExternalEvtGen::decay : There are no particles to decay." << std::endl;
 		return false;
 	}
+
+	EvtSpinDensity* spinDensity = 0;
+	TString parentName = getEvtGenName(parts[0]->id());
 	EvtId theId = EvtPDL::evtIdFromLundKC(parts[0]->id());
+
+	int PDGId = EvtPDL::getStdHep( theId );
+	// std::cout<<"PDGId here:   "<<PDGId<<std::endl;
+    if ( theId.getId() == -1 && theId.getAlias() == -1 ) {
+        std::cout << "Error. Could not find valid EvtId for " << parentName << std::endl;
+        return -1;
+    }
+
+	EvtSpinType::spintype baseSpin = EvtPDL::getSpinType( theId );
+
+    if ( baseSpin == EvtSpinType::VECTOR ) {
+        std::cout << "Setting spin density for vector particle " << parentName << std::endl;
+        spinDensity = new EvtSpinDensity();
+        spinDensity->setDiag( EvtSpinType::getSpinStates( EvtSpinType::VECTOR ) );
+        spinDensity->set( 1, 1, EvtComplex( 0.0, 0.0 ) );
+    }
+
+	// RapidVertex* vtx(0);
+	// vtx = parts[0]->getOriginVertex();
+	
+	// Parent particle XYZ-position
+	// ROOT::Math::XYZPoint point = vtx->getVertex(true);
+	// EvtVector4R origin(0.0, point.X(), point.Y(), point.Z());
+	EvtVector4R origin(0.0, 0.0, 0.0, 0.0);
 
 	// Parent particle 4-momentum
 	TLorentzVector pIn = parts[0]->getP();
 	EvtVector4R pInit(pIn.E(),pIn.Px(),pIn.Py(),pIn.Pz());
+	// double mass = EvtPDL::getMeanMass( theId );
+	// EvtVector4R pInit(mass,0.0, 0.0, 0.0);
 
-	theParent = EvtParticleFactory::particleFactory(theId, pInit);
-	if (theParent->getSpinStates() == 3) {theParent->setVectorSpinDensity();}
+    EvtHepMCEvent* theEvent =
+        evtGen_->generateDecay( PDGId, pInit, origin, spinDensity );	
+	// Retrieve the HepMC event information
+    GenEvent* hepMCEvent = theEvent->getEvent();
 
-	// Generate the event
-	evtGen_->generateDecay(theParent);
+	std::list<GenVertexPtr> allVertices;
+	
+	double flightTime;
 
-	// Store particles to read in the order RapidSim stores them
-	std::queue<EvtParticle*> evtParts;
-	// Also store the number of children expected for each of these particles so we can remove PHOTOS photons
+	int iVtx(0);
+	int iPart(1);
+	bool hasOsc(false);
+
+	TLorentzVector p4TLV;
+	FourVector FourMom;
+	FourVector DecayVtx;
+	FourVector OrigVtx;
+
 	std::queue<int> nExpectedChildren;
-	evtParts.push(theParent);
 	nExpectedChildren.push(parts[0]->nDaughters());
 
-	EvtVector4R x4Evt;
-	EvtVector4R p4Evt;
-	TLorentzVector p4TLV;
+	for ( auto theVertex : hepMCEvent->vertices() ) {
+		if ( theVertex == 0 ) {
+		    continue;
+		}
+		auto nin  = theVertex->particles_in_size();
+		auto nout = theVertex->particles_out_size();
 
-	int iPart=1; // The momentum and origin vertex of the first particle are already set
-
-	while(!evtParts.empty()) {
-		EvtParticle* theParticle = evtParts.front();
-
-		// B0 and Bs may mix in EvtGen - RapidSim ignores this step and only records the second state
-		while(theParticle->getNDaug()==1) {
-			theParticle = theParticle->getDaug(0);
+		while (nin == 1 && nout ==1){
+			//B meson oscillation
+			continue;
 		}
 
 		uint nChildren = nExpectedChildren.front();
 
-		// Loop over the daughter tracks
-		for (uint iChild = 0; iChild < nChildren; ++iChild) {
-			EvtParticle* child = theParticle->getDaug(iChild);
+		// For these, get the mother decay vertex position and the 4-momentum to calculate
+		// the flight time.
 
-			if (child != 0) {
-				p4Evt = child->getP4Lab();
-				x4Evt = child->get4Pos();
-				p4TLV.SetPxPyPzE(p4Evt.get(1),p4Evt.get(2),p4Evt.get(3),p4Evt.get(0));
-				if(parts.size() < iPart+1u) {
-					std::cout << "WARNING in RapidExternalEvtGen::decay : EvtGen has produced too many particles." << std::endl;
-					return false;
-				}
+		for ( auto inParticle : theVertex->particles_in() ) {
+
+        		if ( inParticle == 0 ) {
+        	    	continue;
+        		}
+
+				int inPDGId = inParticle->pdg_id();
+				FourMom = inParticle->momentum();
+				DecayVtx = theVertex->position();
+
+				if ( inPDGId == B0Id || inPDGId == BsId || inPDGId == B0barId || inPDGId == BsbarId ) {
+
+					if (PDGId!=inPDGId){
+						hasOsc=true;
+					}
+					else{
+						hasOsc=false;
+
+					}
+
+					parts[iVtx]->setHasOsc(hasOsc);
+					
+				}				
+
+				flightTime = calcFlightTime( DecayVtx, FourMom );
+				parts[iVtx]->setId(inPDGId);
+				parts[iVtx]->setDecaytime(flightTime);
+				parts[iVtx]->getDecayVertex()->setXYZ(DecayVtx.x(), DecayVtx.y(), DecayVtx.x());
+							
+		}  
+
+		uint nRecorded(0);
+		for ( auto outParticle : theVertex->particles_out() ) {
+			
+			if (nRecorded < nChildren) {
+
+				FourMom = outParticle->momentum();
+				OrigVtx = theVertex->position();
+
+				p4TLV.SetPxPyPzE(FourMom.px(),FourMom.py(),FourMom.pz(),FourMom.e());
+
+				// std::cout<<"ID:"<<outParticle->pdg_id()<<std::endl;
+				// std::cout<<"px: "<<FourMom.px()<<std::endl;
+				// std::cout<<"py: "<<FourMom.py()<<std::endl;
+				// std::cout<<"pz: "<<FourMom.pz()<<std::endl;
+				// std::cout<<""<<std::endl;
+
 				parts[iPart]->setP(p4TLV);
-				parts[iPart]->getOriginVertex()->setXYZ(x4Evt.get(1),x4Evt.get(2),x4Evt.get(3));
-				evtParts.push(child);
-				nExpectedChildren.push(parts[iPart]->nDaughters());
-				++iPart;
-			}
-		}
 
-		// Clean up any PHOTOS photons
-		for (uint iChild = nChildren; iChild < theParticle->getNDaug(); ++iChild) {
-			delete theParticle->getDaug(iChild);
+				parts[iPart]->getOriginVertex()->setXYZ(OrigVtx.x(),OrigVtx.y(),OrigVtx.z());
+				parts[iPart]->setId(outParticle->pdg_id());
+
+				nExpectedChildren.push(parts[iPart]->nDaughters());
+
+				++iPart;
+
+			}
+			++nRecorded;
+			
 		}
-		delete theParticle;
-		evtParts.pop();
 		nExpectedChildren.pop();
+		++iVtx;
 	}
+
+	delete hepMCEvent;
 
 	return true;
 #else
@@ -152,8 +234,11 @@ bool RapidExternalEvtGen::setupGenerator() {
 		decPath += "/config/evtgen/DECAY.DEC";
 	}
 
+	int mixingType = EvtCPUtil::Incoherent;
+	// int mixingType = EvtCPUtil::Coherent;
+
 	evtGen_ = new EvtGen(decPath.Data(), evtPDLPath.Data(), randomEngine,
-			radCorrEngine, &extraModels);
+			radCorrEngine, &extraModels, mixingType);
 
 	return true;
 #else
@@ -173,10 +258,27 @@ void RapidExternalEvtGen::writeDecFile(TString fname, std::vector<RapidParticle*
 	fout.open(decFileName_, std::ofstream::out);
 
 	if(usePhotos) {
-		fout << "yesPhotos\n" << std::endl;
+		fout << "yesFSR\n" << std::endl;
 	} else {
-		fout << "noPhotos\n" << std::endl;
+		fout << "noFSR\n" << std::endl;
 	}
+	TString defString;
+	for(unsigned int iPart=0; iPart<parts.size(); ++iPart) {
+		if(parts[iPart]->evtGenDefinitions()){
+			defString = parts[iPart]->evtGenDefinitions();
+			TObjArray* tokens = defString.Tokenize(",");
+			for (int i = 0; i < tokens->GetEntries(); i++) {
+    			TString token = tokens->At(i)->GetName();
+    			token = token.Strip(TString::kBoth);  // removes leading and trailing whitespace
+    			std::cout << "INFO: Defining in DecFile: " << token << std::endl;
+				fout << "Define " << token << std::endl;
+			}
+			delete tokens;
+		}
+
+	}
+
+	fout << "\n" ;
 
 	// Loop over all particles and write out Decay rule for each
 	for(unsigned int iPart=0; iPart<parts.size(); ++iPart) {
@@ -225,4 +327,27 @@ TString RapidExternalEvtGen::getEvtGenConjName(int id) {
 	std::cout << "WARNING in RapidExternalEvtGen::getEvtGenConjName : EvtGen extension not compiled. Cannot lookup conjugate name for particle ID " << id << "." << std::endl;
 	return "";
 #endif
+}
+
+double RapidExternalEvtGen::calcFlightTime( FourVector& DecayVtx, FourVector& P4mtm )
+{
+    double flightTime( 0.0 );
+
+#ifdef EVTGEN_HEPMC3
+    double distance = DecayVtx.length();    // mm
+    double momentum = P4mtm.length();       // GeV/c
+	double mass = P4mtm.m();
+#else
+    double distance = DecayVtx.rho();    // mm
+    double momentum = P4mtm.rho();  
+	double mass = P4mtm.m();
+#endif
+
+	double c0 = EvtConst::c ;//mm/s
+    if ( momentum > 0.0 ) {
+        flightTime = 1.0e12 * distance * mass /
+                     ( momentum * c0 );    // picoseconds
+    }
+
+	return flightTime;
 }

--- a/src/RapidExternalEvtGen.h
+++ b/src/RapidExternalEvtGen.h
@@ -4,6 +4,8 @@
 #include "TString.h"
 
 #include "RapidExternalGenerator.h"
+#include "EvtGenBase/EvtParticle.hh"
+#include "EvtGenBase/EvtHepMCEvent.hh"
 
 #ifdef RAPID_EVTGEN
 class EvtGen;
@@ -28,6 +30,7 @@ class RapidExternalEvtGen : public RapidExternalGenerator {
 		static TString getEvtGenConjName(int id);
 
 	private:
+		double calcFlightTime( FourVector& BDecayVtx, FourVector& B4mtm );
 #ifdef RAPID_EVTGEN
 		EvtGen* evtGen_;
 #else
@@ -37,4 +40,3 @@ class RapidExternalEvtGen : public RapidExternalGenerator {
 };
 
 #endif
-

--- a/src/RapidParam.cc
+++ b/src/RapidParam.cc
@@ -19,6 +19,11 @@ double RapidParam::eval() {
 	double minip   = particles_[0]->getMinIP();
 	double ipSigma = particles_[0]->getSigmaIP();
 	double minipSigma = particles_[0]->getSigmaMinIP();
+	
+	double decaytime = particles_[0]->t();
+	int id = particles_[0]->id();
+	bool hasOsc = particles_[0]->hasOsc();
+
 	mom_.SetPxPyPzE(0.,0.,0.,0.);
 	if(truth_) {
 		for(unsigned int i=0; i<particles_.size(); ++i) {
@@ -73,6 +78,12 @@ double RapidParam::eval() {
 			return minipSigma;
 		case RapidParam::FD:
 			return fd;
+		case RapidParam::decaytime:
+			return decaytime;
+		case RapidParam::ID:
+			return id;	
+		case RapidParam::hasOsc:
+			return hasOsc;						
 		case RapidParam::ProbNNmu:
 		case RapidParam::ProbNNpi:
 		case RapidParam::ProbNNk:
@@ -170,6 +181,12 @@ bool RapidParam::canBeSmeared() {
 			return true;
 		case RapidParam::OrigZ:
 			return true;
+		case RapidParam::ID:
+			return false;	
+		case RapidParam::decaytime:
+			return false;	
+		case RapidParam::hasOsc:
+			return false;								
 		case RapidParam::UNKNOWN:
 			return true;
 	}
@@ -248,6 +265,12 @@ bool RapidParam::canBeTrue() {
 			return true;
 		case RapidParam::OrigZ:
 			return true;
+		case RapidParam::ID:
+			return false;	
+		case RapidParam::decaytime:
+			return false;		
+		case RapidParam::hasOsc:
+			return false;									
 		case RapidParam::UNKNOWN:
 			return true;
 	}
@@ -274,6 +297,23 @@ double RapidParam::evalPID() {
 	}
 	return pid;
 }
+
+// double RapidParam::evalID() {
+	
+// 	RapidParticleData * particleData = RapidParticleData::getInstance();
+// 	int id(0);
+// 	if (particles_[0]->massHypothesisName() == "") id = particles_[0]->id();
+// 	else id = particleData->pdgCode(particles_[0]->massHypothesisName());
+	
+// 	return id;
+// }
+// double RapidParam::evalDecayTime() {
+	
+// 	RapidParticleData * particleData = RapidParticleData::getInstance();
+// 	int decaytime(0);
+// 	decaytime = particles_[0]->t();
+// 	return decaytime;
+// }
 
 double RapidParam::evalCorrectedMass() {
 
@@ -458,6 +498,12 @@ TString RapidParam::typeName() {
 			return "origY";
 		case RapidParam::OrigZ:
 			return "origZ";
+		case RapidParam::ID:
+			return "ID";	
+		case RapidParam::decaytime:
+			return "decaytime";		
+		case RapidParam::hasOsc:
+			return "hasOsc";									
 		default:
 			std::cout << "WARNING in RapidParam::typeName : unknown type " << type_ << "." << std::endl
 				  << "                                  returning empty string." << std::endl;
@@ -534,6 +580,12 @@ RapidParam::ParamType RapidParam::typeFromString(TString str) {
 		return RapidParam::OrigY;
 	} else if(str=="origZ") {
 		return RapidParam::OrigZ;
+	} else if(str=="ID") {
+		return RapidParam::ID;
+	} else if(str=="decaytime") {
+		return RapidParam::decaytime;
+	} else if(str=="hasOsc") {
+		return RapidParam::hasOsc;		
 	} else {
 		std::cout << "WARNING in RapidParam::typeFromString : unknown type name " << str << "." << std::endl
 			  << "                                        returning mass parameter type." << std::endl;

--- a/src/RapidParam.h
+++ b/src/RapidParam.h
@@ -48,6 +48,9 @@ class RapidParam {
 			OrigX,    // x coordinate of origin vertex
 			OrigY,    // y coordinate of origin vertex
 			OrigZ,    // z coordinate of origin vertex
+			ID,       // TRUE ID of the particle
+			hasOsc,   // whether the particle has oscillated before decay
+			decaytime, // decaytime of the particle
 			UNKNOWN   //unused
 
 		};
@@ -101,6 +104,8 @@ class RapidParam {
 		double evalCorrectedMass();
 		double evalTheta();
 		double evalPID();
+		// double evalID();
+		// double evalDecayTime();
 		double evalPos();
 
 		void setDefaultMinMax() {setDefaultMinMax(particles_,minVal_,maxVal_);}//TODO remove/make virtual and give a warning in the base class

--- a/src/RapidParticle.h
+++ b/src/RapidParticle.h
@@ -55,6 +55,8 @@ class RapidParticle {
 		double charge() { return charge_; }
 		double minMass() { return minMass_; }
 		double maxMass() { return maxMass_; }
+		double t() {return t_; }
+		bool hasOsc() {return hasOsc_;}
 
 		RapidVertex * getOriginVertex() {return originVertex_;}
 		RapidVertex * getDecayVertex() {return decayVertex_;}
@@ -92,7 +94,9 @@ class RapidParticle {
 		void setMinIPSigma(double sigma) { sigmaminip_ = sigma; }
 		//
 		void setPtEtaPhi(double pt, double eta, double phi) { p_.SetPtEtaPhiM(pt,eta,phi,mass_); }
-
+		void setDecaytime(double t) { t_ = t; }
+		void setHasOsc(bool hasOsc) { hasOsc_ = hasOsc; }
+		void setId(int id) { id_ = id; }
 		void print(int index);
 
 		void setMassShape(RooDataSet* ds, double minMass, double maxMass, TString varName);
@@ -100,6 +104,9 @@ class RapidParticle {
 
 		TString evtGenDecayModel() { return evtGenModel_; }
 		void setEvtGenDecayModel(TString value) { evtGenModel_ = value; }
+
+		TString evtGenDefinitions() { return evtGenDefs_; }
+		void setEvtGenDefinitions(TString value) { evtGenDefs_ = value; }
 
 	private:
 		bool hasFlavour(int flavour);
@@ -131,6 +138,8 @@ class RapidParticle {
 		double sigmaminip_;
 		double ipSmeared_;
 		double minipSmeared_;
+		double t_;
+		bool hasOsc_;
 		TLorentzVector p_;
 		TLorentzVector pSmeared_;
 
@@ -145,6 +154,7 @@ class RapidParticle {
 		TString varName_;
 
 		TString evtGenModel_;
+		TString evtGenDefs_;
 
 		//store alternative mass hypotheses
 		std::vector<TString> massHypothesisNames_;

--- a/src/RapidParticleData.cc
+++ b/src/RapidParticleData.cc
@@ -15,6 +15,9 @@ RapidParticleData* RapidParticleData::getInstance() {
 	if(!instance_) {
 		instance_ = new RapidParticleData();
 		TString path;
+                path=getenv("RAPIDSIM_PARTICLE_TABLE");
+                if(path!="") instance_->loadData(path);
+
 		path=getenv("RAPIDSIM_CONFIG");
 		if(path!="") instance_->loadData(path+"/config/particles.dat");
 
@@ -215,6 +218,7 @@ void RapidParticleData::addEntry(int id, TString name, double mass, double width
 	if(idToName_.find(id) != idToName_.end()) {
 		std::cout << "INFO in RapidParticleData::addEntry : particle with ID " << id << " already defined with name " << idToName_[id] << std::endl;
 		std::cout << "                                      second definition will be ignored." << std::endl;
+          return;
 	}
 
 	idToCT_[id] = ctau;


### PR DESCRIPTION
This pull request aims at storing decay length and flight time information from external generators, e.g. If oscillation is enabled in EvtGen, B decay time can be saved to ntuple to include oscillation effects. It does so by using HepMCEvent as it is shown in EvtGen's examples (eg [here](https://gitlab.cern.ch/evtgen/evtgen/-/blob/master/validation/testCPVDecays.cc?ref_type=heads))


In particular, this MR aims at:


1) Enabling definition of variables that will be written in the .DEC file with the syntax:

```
@0
    name : B0
    Define : dm_incohMix_B0 0.507e12, dgog 0.000, qoverp_incohMix_B0 1.00, argqoverp -0.775
    evtGenModel: SSD_CP dm_incohMix_B0 dgog qoverp_incohMix_B0 argqoverp 1.0 0.0 1.0 0.0
```

2) If `dm_incohMix_B0` or `dm_incohMix_B0s` are defined this will enable B meson oscillations if your EvtGen model includes them

Test with the following decay and config files:

`Bs0 -> {KS -> pi+ pi-} {Jpsi -> mu+ mu-}`

```
geometry : 4pi
energy: 13

paramsDecaying : M, P, PT, PX, PY, PZ, E, vtxX, vtxY, vtxY, vtxZ, origX, origY, origZ, eta, FD
paramsStable : M, P, PT, PX, PY, PZ, E, IP, eta, MINIP


param : B0_ID ID 0
param : B0_HasOsc hasOsc 0
param : B0_decaytime decaytime 0
param : KS0_decaytime decaytime 1
param : JPsi_decaytime decaytime 2


useEvtGen : TRUE
evtGenUsePHOTOS : TRUE

@0
    name : B0
    Define : dm_incohMix_B0 0.507e12, dgog 0.000, qoverp_incohMix_B0 1.00, argqoverp -0.775
    evtGenModel: SSD_CP dm_incohMix_B0 dgog qoverp_incohMix_B0 argqoverp 1.0 0.0 1.0 0.0
@1
    name : KS0
    evtGenModel: PHSP
@2
    name : JPsi
    evtGenModel: VLL
@3
    name : Pip
    smear : LHCbGeneric
@4
    name : Pim
    smear : LHCbGeneric
@5
    name : mup
    smear : LHCbGeneric
@6
    name : mum
    smear : LHCbGeneric
```